### PR TITLE
Type conversion issue for creating read replicas

### DIFF
--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -842,8 +842,10 @@ def get_parameters(client, module, parameters, method_name):
     if parameters.get('ProcessorFeatures') == [] and not method_name == 'modify_db_instance':
         parameters.pop('ProcessorFeatures')
 
-    if method_name == 'create_db_instance' and parameters.get('Tags'):
-        parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
+    if method_name == 'create_db_instance' or method_name == 'create_db_instance_read_replica':
+        if parameters.get('Tags'):
+            parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
+        
     if method_name == 'modify_db_instance':
         parameters = get_options_with_changing_values(client, module, parameters)
 


### PR DESCRIPTION
When create_db_instance is called, it converts the dict to a tag list, but this is not happening when create_db_instance_read_replica is called, which causes:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Tags, value: <TAGS LISTED HERE>, type: <class 'dict'>, valid types: <class 'list'>, <class 'tuple'>
```

This patch just calls the same date type conversion in both cases.